### PR TITLE
Don't fail if we cannot write to directory during rebuild.js

### DIFF
--- a/rebuild.js
+++ b/rebuild.js
@@ -7,11 +7,15 @@ if (verbose) {
   if (p.status || p.signal || p.error) {
     console.log('ursaNative bindings compilation fail. This is not an issue. Modules that depend on it will use fallbacks.');
     var fs = require('fs');
-    if (p.error) {
-      fs.writeFileSync('./stderr.log', p.error.stack);
-    } else {
-      fs.writeFileSync('./stdout.log', p.stdout);
-      fs.writeFileSync('./stderr.log', p.stderr);
+    try {
+      if (p.error) {
+        fs.writeFileSync('./stderr.log', p.error.stack);
+      } else {
+        fs.writeFileSync('./stdout.log', p.stdout);
+        fs.writeFileSync('./stderr.log', p.stderr);
+      }
+    } catch (e) {
+      console.log('Cannot log errors', e)
     }
   }
 }


### PR DESCRIPTION
We have the issue that ursa fails to install with:

```
Error: EACCES: permission denied, open './stdout.log'
```

Ursa should never fail to install (see readme), so instead, let's swallow the error and continue.

(Ref https://github.com/hoprnet/hoprnet/issues/597)